### PR TITLE
Improve formatting of inline code to avoid potential pink boxing

### DIFF
--- a/Developer/Resources/Styles.wl
+++ b/Developer/Resources/Styles.wl
@@ -205,16 +205,6 @@ Cell[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
-(*ChatCodeBlock*)
-Cell[
-    StyleData[ "ChatCodeBlock" ],
-    FrameBoxOptions -> {
-
-    }
-]
-
-(* ::**************************************************************************************************************:: *)
-(* ::Section::Closed:: *)
 (*Input*)
 Cell[
     StyleData[ "Input" ],
@@ -313,6 +303,74 @@ Cell[
                 ],
                 Appearance -> $suppressButtonAppearance
             ]
+        ]
+    }
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Chat Output Formatting*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*ChatCodeBlock*)
+Cell[
+    StyleData[ "ChatCodeBlock" ],
+    Background -> GrayLevel[ 1 ]
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*ChatCode*)
+Cell[
+    StyleData[ "ChatCode", StyleDefinitions -> StyleData[ "Input" ] ],
+    Background           -> GrayLevel[ 1 ],
+    FontSize             -> 14,
+    FontWeight           -> "Plain",
+    LanguageCategory     -> "Input",
+    ShowAutoStyles       -> True,
+    ShowStringCharacters -> True,
+    ShowSyntaxStyles     -> True
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*ChatCodeActive*)
+Cell[
+    StyleData[ "ChatCodeActive", StyleDefinitions -> StyleData[ "ChatCode" ] ],
+    ShowAutoStyles -> False
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*ChatCodeBlockTemplate*)
+Cell[
+    StyleData[ "ChatCodeBlockTemplate" ],
+    TemplateBoxOptions -> {
+        DisplayFunction -> Function @ FrameBox[
+            #,
+            Background   -> GrayLevel[ 1 ],
+            FrameMargins -> { { 10, 10 }, { 6, 6 } },
+            FrameStyle   -> Directive[ AbsoluteThickness[ 1 ], GrayLevel[ 0.92941 ] ],
+            ImageMargins -> { { 0, 0 }, { 8, 8 } },
+            ImageSize    -> { Full, Automatic }
+        ]
+    }
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*ChatCodeInlineTemplate*)
+Cell[
+    StyleData[ "ChatCodeInlineTemplate" ],
+    TemplateBoxOptions -> {
+        DisplayFunction -> Function @ FrameBox[
+            #1,
+            Background       -> GrayLevel[ 1 ],
+            BaselinePosition -> Scaled[ 0.275 ],
+            FrameMargins     -> { { 3, 3 }, { 2, 2 } },
+            FrameStyle       -> Directive[ AbsoluteThickness[ 1 ], GrayLevel[ 0.92941 ] ],
+            ImageMargins     -> { { 0, 0 }, { 0, 0 } }
         ]
     }
 ]

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -871,7 +871,6 @@ Notebook[
    FontSize -> 6,
    Background -> GrayLevel[0.95]
   ],
-  Cell[StyleData["ChatCodeBlock"]],
   Cell[
    StyleData["Input"],
    StyleKeyMapping -> {
@@ -1201,6 +1200,64 @@ Notebook[
         ],
        Evaluator -> Automatic,
        Method -> "Preemptive"
+      ]
+     ])
+   }
+  ],
+  Cell[
+   StyleData["ChatCodeBlock"],
+   Background -> GrayLevel[1]
+  ],
+  Cell[
+   StyleData[
+    "ChatCode",
+    StyleDefinitions -> StyleData["Input"]
+   ],
+   ShowAutoStyles -> True,
+   ShowSyntaxStyles -> True,
+   LanguageCategory -> "Input",
+   ShowStringCharacters -> True,
+   FontSize -> 14,
+   FontWeight -> "Plain",
+   Background -> GrayLevel[1]
+  ],
+  Cell[
+   StyleData[
+    "ChatCodeActive",
+    StyleDefinitions -> StyleData["ChatCode"]
+   ],
+   ShowAutoStyles -> False
+  ],
+  Cell[
+   StyleData["ChatCodeBlockTemplate"],
+   TemplateBoxOptions -> {
+    DisplayFunction ->
+     (Function[
+      FrameBox[
+       #1,
+       Background -> GrayLevel[1],
+       FrameMargins -> {{10, 10}, {6, 6}},
+       FrameStyle ->
+        Directive[AbsoluteThickness[1], GrayLevel[0.92941]],
+       ImageMargins -> {{0, 0}, {8, 8}},
+       ImageSize -> {Full, Automatic}
+      ]
+     ])
+   }
+  ],
+  Cell[
+   StyleData["ChatCodeInlineTemplate"],
+   TemplateBoxOptions -> {
+    DisplayFunction ->
+     (Function[
+      FrameBox[
+       #1,
+       Background -> GrayLevel[1],
+       BaselinePosition -> Scaled[0.275],
+       FrameMargins -> {{3, 3}, {2, 2}},
+       FrameStyle ->
+        Directive[AbsoluteThickness[1], GrayLevel[0.92941]],
+       ImageMargins -> {{0, 0}, {0, 0}}
       ]
      ])
    }


### PR DESCRIPTION
This fixes an issue where inline code could fail to format due to timing out while loading DefinitionNotebookClient for a dependent function:

<img width="674" alt="image" src="https://user-images.githubusercontent.com/6674723/233797063-0b10ea93-e985-45a1-a067-9b617a16a231.png">

This PR removes the dependency on that function and should render chat outputs a bit faster overall.