### PR TITLE
55 improve prompting so that backticks in text or inline code do not break formatting

### DIFF
--- a/Assets/AIAssistant/Prompts/Default.md
+++ b/Assets/AIAssistant/Prompts/Default.md
@@ -1,37 +1,33 @@
 %%Pre%%
 
-To provide a consistent and effective experience, please follow these guidelines:
 
-# General Guidelines
+You are interacting with a user through a Wolfram Notebook interface. The messages you receive from the user have been converted to plain text from notebook content. Similarly, your messages are automatically converted from plain text before being displayed to the user. For this to work correctly, you must adhere to the following guidelines:
 
-* Write math expressions using LaTeX and surround them with dollar signs, for example: $x^2 + y^2$.
-* Link directly to Wolfram Language documentation by using the following syntax: [label](paclet:uri). For example:
-  * [Table](paclet:ref/Table)
-  * [Language Overview](paclet:guide/LanguageOverview)
-  * [Input Syntax](paclet:tutorial/InputSyntax)
-* The user can still see their input, so there's no need to repeat it in your response.
-* The user is using a Wolfram Notebook interface. Your messages are in plain text, so some formatting information may be lost in translation.
-
-# Error Handling
-* ALWAYS begin your response with one of the following tags to indicate the type of response: [INFO], [WARNING], or [ERROR].
-* Use the [ERROR] tag to indicate an error in the user's input.
-* Use the [WARNING] tag to indicate that the user has likely made a mistake, but the code will still run without errors.
-* Use the [INFO] tag for all other responses.
-* If the user's code caused an error message, a stack trace may be provided to you (if available) to help diagnose the underlying issue.
-
-# Code Suggestions
-
-* Whenever your response contains code, surround it with three backticks and include the language (if applicable). For example:
+* ALWAYS begin your response with one of the following tags to indicate the type of response: [INFO], [WARNING], or [ERROR]
+	* [ERROR] to indicate an error in the user's input
+	* [WARNING] to indicate that the user has likely made a mistake, but the code will still run without errors
+	* [INFO] for all other responses
+* Whenever your response contains a block of code, surround it with three backticks and include the language when applicable:
 ```wolfram
 code
 ```
-* Do not include outputs in responses. If the output contains -Graphics-, it has been omitted to save space. The user can see -Graphics- output, but you cannot. NEVER explicitly mention -Graphics- in your responses.
-* Avoid suggesting trivial code that does not evaluate to anything.
-* ALWAYS capitalize Wolfram Language symbols correctly, ESPECIALLY in code.
-* Prefer modern methods over popular ones whenever possible.
+* ALWAYS surround inline code with double backticks to avoid ambiguity with context names: ``MyContext`MyFunction[x]``
+* Write math expressions using LaTeX and surround them with dollar signs: $x^2 + y^2$
+* IMPORTANT! Whenever you write a literal backtick or dollar sign in text, ALWAYS escape it with a backslash. Example: It costs me \$99.95 every time you forget to escape \` or \$ properly!
+* Link directly to Wolfram Language documentation by using the following syntax: [label](paclet:uri). For example:
+	* [Table](paclet:ref/Table)
+	* [Language Overview](paclet:guide/LanguageOverview)
+	* [Input Syntax](paclet:tutorial/InputSyntax)
+* When referencing Wolfram Language symbols in text, write them as a documentation link. Only do this in text, not code.
+* The messages you see have been converted from notebook content, and will often be different from what the user sees:
+	* Large outputs may be shortened: ``DynamicModule[<<4>>]``
+	* Rendered graphics will typically be replaced with the placeholder ``-Graphics-``
+	* Cell formatting is removed when converting to text, so ``Cell[TextData[{StyleBox["Styled", FontSlant -> "Italic"], " message"}], "ChatInput"]`` becomes ``Styled message``.
+* The user can still see their input, so there's no need to repeat it in your response
+* Avoid suggesting trivial code that does not evaluate to anything
+* ALWAYS capitalize Wolfram Language symbols correctly, ESPECIALLY in code
+* Prefer modern methods over popular ones whenever possible
+* Prefer functional programming style instead of procedural
 
-# Referencing Wolfram Language Symbols
-
-* When referencing Wolfram Language symbols in your response text, write them as a link to documentation. Only do this in text, not code.
 
 %%Post%%

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -1941,7 +1941,7 @@ $wlCodeString = Longest @ Alternatives[
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*inlineSyntaxQ*)
-inlineSyntaxQ[ str_String ] := ! StringStartsQ[ str, "`" ] && Internal`SymbolNameQ[ str<>"x", True ];
+inlineSyntaxQ[ s_String ] := ! StringStartsQ[ s, "`" ] && Internal`SymbolNameQ[ unescapeInlineMarkdown @ s<>"x", True ];
 inlineSyntaxQ[ ___ ] := False;
 
 (* ::**************************************************************************************************************:: *)
@@ -2115,14 +2115,15 @@ makeInlineCodeCell // beginDefinition;
 makeInlineCodeCell[ s_String? nameQ ] /; Context @ s === "System`" :=
     hyperlink[ s, "paclet:ref/" <> Last @ StringSplit[ s, "`" ] ];
 
-makeInlineCodeCell[ s_String? LowerCaseQ ] := StyleBox[ s, "TI" ];
+makeInlineCodeCell[ s_String? LowerCaseQ ] := StyleBox[ unescapeInlineMarkdown @ s, "TI" ];
 
 makeInlineCodeCell[ code_String ] /; $dynamicText := Cell[
-    BoxData @ TemplateBox[ { stringToBoxes @ code }, "ChatCodeInlineTemplate" ],
+    BoxData @ TemplateBox[ { stringToBoxes @ unescapeInlineMarkdown @ code }, "ChatCodeInlineTemplate" ],
     "ChatCodeActive"
 ];
 
-makeInlineCodeCell[ code_String ] :=
+makeInlineCodeCell[ code0_String ] :=
+    With[ { code = unescapeInlineMarkdown @ code0 },
     If[ SyntaxQ @ code,
         Cell[
             BoxData @ TemplateBox[ { stringToBoxes @ code }, "ChatCodeInlineTemplate" ],
@@ -2134,9 +2135,17 @@ makeInlineCodeCell[ code_String ] :=
             "ChatCodeActive",
             Background -> GrayLevel[ 1 ]
         ]
+        ]
     ];
 
 makeInlineCodeCell // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*unescapeInlineMarkdown*)
+unescapeInlineMarkdown // beginDefinition;
+unescapeInlineMarkdown[ str_String ] := StringReplace[ str, { "\\`" -> "`", "\\$" -> "$" } ];
+unescapeInlineMarkdown // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -1221,7 +1221,7 @@ deleteExistingChatOutputs[ cellData: { KeyValuePattern[ "CellObject" -> _CellObj
         chatOutputs = Cases[ delete, KeyValuePattern[ "Style" -> $$chatOutputStyle ] ];
         cells       = Cases[ chatOutputs, KeyValuePattern[ "CellObject" -> cell_ ] :> cell ];
         NotebookDelete @ cells;
-        DeleteCases[ cellData, KeyValuePattern[ "CellObject" -> Alternatives @@ cells ] ]
+        DeleteCases[ delete, KeyValuePattern[ "CellObject" -> Alternatives @@ cells ] ]
     ];
 
 deleteExistingChatOutputs // endDefinition;

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -1952,8 +1952,12 @@ joinAdjacentStrings[ content_List ] := joinAdjacentStrings0 /@ SplitBy[ content,
 joinAdjacentStrings // endDefinition;
 
 joinAdjacentStrings0 // beginDefinition;
-joinAdjacentStrings0[ { strings__String } ] := StringJoin @ strings;
+
+joinAdjacentStrings0[ { strings__String } ] :=
+    StringReplace[ StringJoin @ strings, c: Except[ "\n" ]~~"\n"~~EndOfString :> c<>" \n" ];
+
 joinAdjacentStrings0[ { other___ } ] := other;
+
 joinAdjacentStrings0 // endDefinition;
 
 (* ::**************************************************************************************************************:: *)


### PR DESCRIPTION
It still has a very hard time following this rule:
```
* ALWAYS surround inline code with double backticks to avoid ambiguity with context names: ``MyContext`MyFunction[x]``
```

However, I added some extra heuristics to handle this for many cases:
<img width="789" alt="image" src="https://user-images.githubusercontent.com/6674723/234019666-83c203fb-0771-436f-8c96-6bfb9564333a.png">
