### PR TITLE
58 suggestion show cell bracket on hover for context divider cells

### DIFF
--- a/Developer/Resources/Styles.wl
+++ b/Developer/Resources/Styles.wl
@@ -173,7 +173,6 @@ Cell[
     CellMargins            -> { { 0, 0 }, { 10, 10 } },
     DefaultNewCellStyle    -> "Input",
     FontSize               -> 6,
-    ShowCellBracket        -> False,
     ShowCellLabel          -> False,
 
     CellEventActions -> {

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -817,7 +817,6 @@ Notebook[
   ],
   Cell[
    StyleData["ChatDelimiter"],
-   ShowCellBracket -> False,
    CellMargins -> {{0, 0}, {10, 10}},
    CellElementSpacings -> {"CellMinHeight" -> 6},
    CellGroupingRules -> {"SectionGrouping", 62},


### PR DESCRIPTION
<img width="584" alt="Screenshot 2023-04-24 105359" src="https://user-images.githubusercontent.com/6674723/234036736-f2c71b87-258b-4145-bf80-e87a374bca68.png">


Note: the cell bracket is being shown by default, since it appears misaligned if it's hover-only:

<img width="584" alt="Screenshot 2023-04-24 105331" src="https://user-images.githubusercontent.com/6674723/234036720-117b39aa-03a9-4120-b56c-4a7dde50f320.png">
